### PR TITLE
Fixed issue with strtotime returning NULL with date formatted in a no…

### DIFF
--- a/includes/misc-functions/event-output.php
+++ b/includes/misc-functions/event-output.php
@@ -632,7 +632,7 @@ function mp_stacks_eventgrid_post_output(){
 							$the_start_time = mp_core_get_post_meta( $post_id, 'event_start_time' );
 
                             //Get END date info if an and date was entered in the original real event post
-                            if (  mp_core_get_post_meta( $post_id, 'event_end_date', 'no_date_entered' ) ) {
+                            if (  mp_core_get_post_meta( $post_id, 'event_end_date' ) ) {
                                 $the_end_date = mp_events_get_mp_event_end_date( $post_id );
                             } else {
                                 $the_end_date = NULL;

--- a/includes/misc-functions/grid-dates-setup.php
+++ b/includes/misc-functions/grid-dates-setup.php
@@ -260,7 +260,7 @@ function mp_stacks_eventgrid_date( $post_id, $word_limit, $read_more_text, $mp_e
 		
 	$the_start_date = mp_events_format_mp_event_date( $mp_event_start_date );
 	$the_start_time = mp_core_get_post_meta( $post_id, 'event_start_time' );
-	$the_start_date_timestamp = strtotime( $the_start_date );
+	$the_start_date_timestamp = strtotime( $mp_event_start_date );
 	$the_start_date = date( get_option( 'date_format' ), $the_start_date_timestamp );
 	$time_description = mp_core_get_post_meta( $post_id, 'event_time_description', $the_start_time );
 	

--- a/includes/misc-functions/grid-dates-setup.php
+++ b/includes/misc-functions/grid-dates-setup.php
@@ -264,13 +264,14 @@ function mp_stacks_eventgrid_date( $post_id, $word_limit, $read_more_text, $mp_e
 	$the_start_date = date( get_option( 'date_format' ), $the_start_date_timestamp );
 	$time_description = mp_core_get_post_meta( $post_id, 'event_time_description', $the_start_time );
 	
+	$shortMonth = datefmt_format_object(new DateTime($mp_event_start_date), 'MMM', get_locale());
 	//Add the calendar-style date output (fancy)
 	$the_fancy_date = '
 	<div class="mp-stacks-eventgrid-item-date-holder">
 		<div class="mp-stacks-eventgrid-fancy-date">
 			<figure>
 				<header>
-					<span class="mp-stacks-eventgrid-month">' . date( 'M', $the_start_date_timestamp ) . '</span>
+					<span class="mp-stacks-eventgrid-month">' . $shortMonth . '</span>
 					<span class="mp-stacks-eventgrid-year">' . date( 'Y', $the_start_date_timestamp ) . '</span>
 				</header>
 				<section>' . date( 'j', $the_start_date_timestamp ) . '</section>


### PR DESCRIPTION
…n-English locale

Fixed issue that caused dates which where regionally formatted as dd/MM/YYYY to be converted incorrectly. (For instance Sep. 27, 2018 was first being formatted as per the locale such that it was written 27/09/2018, and then was passed to strtotime() which explicitly expects either English formatted dates or a date in the ISO8601 format. Modified the code to pass the $mp_event_start_date into the call to strtotime() since $mp_event_start_date is holding the date in an ISO8601 format.

Also modified the date formatting code to consider the WP Locale when formatting the date into an abbreviated string

Also fixed the issue of displaying an end date when there is no end date specified.